### PR TITLE
fix: domain change exits early in non-TTY, engine never restarts

### DIFF
--- a/mtproxymax.sh
+++ b/mtproxymax.sh
@@ -7079,8 +7079,13 @@ cli_main() {
                         save_settings
                         log_success "Domain changed to ${new_domain}"
                         log_warn "Existing proxy links still encode the old domain"
-                        echo -en "  ${BOLD}Rotate all secrets for new domain? [Y/n]:${NC} "
-                        local _rot; read -r _rot
+                        local _rot="y"
+                        if [ -t 0 ]; then
+                            echo -en "  ${BOLD}Rotate all secrets for new domain? [Y/n]:${NC} "
+                            read -r _rot || _rot="y"
+                        else
+                            log_info "Non-interactive mode: rotating secrets and restarting automatically"
+                        fi
                         if [[ ! "$_rot" =~ ^[nN] ]]; then
                             local _ri
                             for _ri in "${!SECRETS_LABELS[@]}"; do


### PR DESCRIPTION
## Problem

When `mtproxymax domain <new>` is run without a TTY — for example via a non-interactive SSH command, a CI script, or the Telegram bot — the script exits silently before restarting the engine. The result: `settings.conf` and `config.toml` are updated with the new domain, but the **running telemt container continues using the old domain in memory**. Every client connection using the new domain's SNI is rejected as `unknown SNI` and forwarded to the masking target instead.

### Root cause

The script uses `set -eo pipefail` (line 10). Line 7083 contains a bare `read`:

```bash
echo -en "  ${BOLD}Rotate all secrets for new domain? [Y/n]:${NC} "
local _rot; read -r _rot    # ← returns exit code 1 on EOF (no TTY)
```

When stdin is not a TTY, `read` receives immediate EOF and returns exit code 1. With `set -e` active, the script exits here — **before** `save_secrets` and **before** `restart_proxy_container` are ever reached.

The output appears successful (`[✓] Domain changed to ...`) because the log line runs before `read`, so callers have no indication anything went wrong.

### Observed symptoms

```
# Non-interactive invocation:
$ ssh host 'mtproxymax domain www.yandex.ru'
  [✓] Domain changed to www.yandex.ru
  [!] Existing proxy links still encode the old domain
  [Y/n]:
# Script exits here. No restart. No secret rotation.

# Engine logs immediately after:
TLS handshake rejected by unknown SNI policy peer=<CLIENT_IP> sni=www.yandex.ru unknown_sni=true unknown_sni_action=Mask
# ↑ Every client with the new SNI is rejected until manual restart
```

Note: even sending `SIGHUP` (via `mtproxymax secret add/remove`) does not fix this — telemt does not reload `tls_domain` from SIGHUP, only secrets. A full container restart is required.

## Fix

Check `[ -t 0 ]` before attempting `read`. Default to `y` (rotate + restart) in non-interactive mode, print an informational message so the caller knows what happened, and add a `|| _rot="y"` guard on the interactive path as well.

```bash
# Before
echo -en "  ${BOLD}Rotate all secrets for new domain? [Y/n]:${NC} "
local _rot; read -r _rot

# After
local _rot="y"
if [ -t 0 ]; then
    echo -en "  ${BOLD}Rotate all secrets for new domain? [Y/n]:${NC} "
    read -r _rot || _rot="y"
else
    log_info "Non-interactive mode: rotating secrets and restarting automatically"
fi
```

The default of `y` (rotate) is the safest choice: after a domain change, old secrets encode the old domain, so rotating them ensures distributed links work immediately after restart.

## Related

- Discussed in #31 — the maintainer explicitly listed domain change as requiring restart, but the non-interactive exit bug means that restart was never executed in that context.
- The `domain clear` path (same file, a few lines above) correctly calls `restart_proxy_container` without any `read` guard — this fix brings the `domain set` path into parity.

## Testing

**Interactive (unchanged behaviour):**
```bash
mtproxymax domain www.newdomain.com
# Prompts as before, rotates on Y, skips on N, restarts in both cases
```

**Non-interactive (fixed):**
```bash
ssh host 'mtproxymax domain www.newdomain.com'
# [i] Non-interactive mode: rotating secrets and restarting automatically
# [✓] All secrets rotated — share new links with your users
# [✓] Proxy stopped
# [✓] Proxy is running on port 443
```