### PR TITLE
fix(telegram): report secret command results correctly

### DIFF
--- a/mtproxymax.sh
+++ b/mtproxymax.sh
@@ -4749,8 +4749,10 @@ audit_log() {
     echo "${ts} UTC | ${user} | ${action}" >> "$_AUDIT_LOG"
     # Rotate if over 10000 lines
     local lines; lines=$(wc -l < "$_AUDIT_LOG" 2>/dev/null | tr -d ' ')
-    [[ "$lines" =~ ^[0-9]+$ ]] && [ "$lines" -gt 10000 ] 2>/dev/null && \
+    if [[ "$lines" =~ ^[0-9]+$ ]] && [ "$lines" -gt 10000 ] 2>/dev/null; then
         tail -n 8000 "$_AUDIT_LOG" > "${_AUDIT_LOG}.tmp" && mv "${_AUDIT_LOG}.tmp" "$_AUDIT_LOG"
+    fi
+    return 0
 }
 
 show_history() {
@@ -13008,7 +13010,10 @@ cli_main() {
                     done
                     secret_add "$_add_label" "$_add_secret" "$_no_restart" || return 1
                     # Apply template after creating
-                    [ -n "$_add_template" ] && template_apply "$_add_template" "$_add_label"
+                    if [ -n "$_add_template" ]; then
+                        template_apply "$_add_template" "$_add_label" || return 1
+                    fi
+                    return 0
                     ;;
                 add-batch)
                     check_root
@@ -13029,8 +13034,9 @@ cli_main() {
                     if [ "$_dry" = "true" ]; then
                         log_info "DRY RUN — would remove secret '${_rm_label}' (no changes made)"
                     else
-                        secret_remove "$_rm_label" "false" "$_no_restart"
+                        secret_remove "$_rm_label" "false" "$_no_restart" || return 1
                     fi
+                    return 0
                     ;;
                 remove-batch)
                     check_root

--- a/tests/test_secret_command_status.sh
+++ b/tests/test_secret_command_status.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+# Regression tests for secret CLI exit statuses used by Telegram command handlers.
+set -o pipefail
+
+if [ "${BASH_VERSINFO[0]:-0}" -lt 4 ] || \
+   { [ "${BASH_VERSINFO[0]}" -eq 4 ] && [ "${BASH_VERSINFO[1]:-0}" -lt 2 ]; }; then
+    echo "SKIP: bash 4.2+ required (got ${BASH_VERSION:-unknown})" >&2
+    exit 0
+fi
+
+TEST_TMPDIR=$(mktemp -d)
+INSTALL_DIR="$TEST_TMPDIR/install"
+mkdir -p "$INSTALL_DIR"
+
+MTPROXYMAX_SOURCE_ONLY=true source "$(dirname "$0")/../mtproxymax.sh"
+set +e
+trap 'rm -rf "$TEST_TMPDIR"' EXIT
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+assert_status() {
+    local name="$1" want="$2" got="$3"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if [ "$got" -eq "$want" ]; then
+        printf '  PASS  %s\n' "$name"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        printf '  FAIL  %s (got=%s want=%s)\n' "$name" "$got" "$want"
+    fi
+}
+
+echo "Secret command status tests"
+
+audit_log "test short audit log"
+assert_status "audit_log succeeds when rotation is not needed" 0 "$?"
+
+# Isolate CLI dispatch from host state while exercising the production cli_main.
+load_settings() { :; }
+load_secrets() { :; }
+check_root() { :; }
+log_info() { :; }
+
+SECRET_ADD_STATUS=0
+TEMPLATE_APPLY_STATUS=0
+SECRET_REMOVE_STATUS=0
+
+secret_add() { return "$SECRET_ADD_STATUS"; }
+template_apply() { return "$TEMPLATE_APPLY_STATUS"; }
+secret_remove() { return "$SECRET_REMOVE_STATUS"; }
+
+cli_main secret add alice
+assert_status "secret add without template reports success" 0 "$?"
+
+cli_main secret add alice --template standard
+assert_status "secret add with successful template reports success" 0 "$?"
+
+TEMPLATE_APPLY_STATUS=1
+cli_main secret add alice --template missing
+assert_status "secret add propagates template failure" 1 "$?"
+TEMPLATE_APPLY_STATUS=0
+
+SECRET_ADD_STATUS=1
+cli_main secret add duplicate
+assert_status "secret add propagates creation failure" 1 "$?"
+SECRET_ADD_STATUS=0
+
+cli_main secret remove alice
+assert_status "secret remove reports success" 0 "$?"
+
+SECRET_REMOVE_STATUS=1
+cli_main secret remove missing
+assert_status "secret remove propagates removal failure" 1 "$?"
+
+printf '\n%d tests, %d failures\n' "$TESTS_RUN" "$TESTS_FAILED"
+[ "$TESTS_FAILED" -eq 0 ]


### PR DESCRIPTION
## Summary

  - Prevent `audit_log` from returning a false failure when log rotation is not needed.
  - Make `secret add` and `secret remove` explicitly return success after completed operations.
  - Preserve genuine creation, removal, and template application failures.
  - Add regression tests for CLI exit statuses used by Telegram handlers.

  ## Problem

  The Telegram bot relies on the exit status of:

  - `mtproxymax secret add <label>`
  - `mtproxymax secret remove <label>`

  Both operations could successfully modify `secrets.conf` and hot-reload the proxy configuration, but still return status 1. The bot therefore displayed a
  failure even though the user was actually added or removed.

  ## Tests

  - `bash -n mtproxymax.sh`
  - `bash tests/test_secret_command_status.sh` — 7 passed
  - `bash tests/test_replication.sh` — 112 passed
  - `git diff --check`

