### PR TITLE
fix(guest): preserve labels and apply access limits

### DIFF
--- a/mtproxymax.sh
+++ b/mtproxymax.sh
@@ -6148,9 +6148,9 @@ run_tag() {
         return 0
     fi
     if [ "$tag_str" = "clear" ] || [ "$tag_str" = "remove" ]; then
-        run_secret note "$label" ""
+        secret_edit_note "$label" ""
     else
-        run_secret note "$label" "$tag_str"
+        secret_edit_note "$label" "$tag_str"
     fi
 }
 
@@ -6334,39 +6334,44 @@ EOF
 # ── Suite 2: Commercial & Quota Intelligence Suite ─────────────────────────────
 
 run_guest() {
-    local label="$1"
+    local guest_label="${1:-}"
     local limit_str="${2:-24h}"
-    [ -z "$label" ] && { echo -e "\n  ── ⌛ ${BOLD}Disposable Burner / Guest Links${NC} ──\n\n  ${DIM}Usage: mtproxymax guest <label> <24h|7d|500mb|1gb>${NC}\n"; return 1; }
+    [ -z "$guest_label" ] && { echo -e "\n  ── ⌛ ${BOLD}Disposable Burner / Guest Links${NC} ──\n\n  ${DIM}Usage: mtproxymax guest <label> <24h|7d|500mb|1gb>${NC}\n"; return 1; }
     
     check_root
     load_settings
     load_secrets
     
     local note="🔥 Burner link (${limit_str})"
-    local days=0 quota=0 expires=""
+    local quota=0 expires=""
     
     if [[ "${limit_str,,}" =~ ^([0-9]+)h(ours?)?$ ]]; then
         local hours="${BASH_REMATCH[1]}"
-        days=$(( (hours + 23) / 24 ))
-        [ "$days" -lt 1 ] && days=1
         expires=$(date -u -d "+${hours} hours" "+%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date -u -r $(( $(date +%s) + hours*3600 )) "+%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || echo "")
     elif [[ "${limit_str,,}" =~ ^([0-9]+)d(ays?)?$ ]]; then
-        days="${BASH_REMATCH[1]}"
+        local days="${BASH_REMATCH[1]}"
         expires=$(date -u -d "+${days} days" "+%Y-%m-%d" 2>/dev/null || date -u -r $(( $(date +%s) + days*86400 )) "+%Y-%m-%d" 2>/dev/null || echo "")
     elif [[ "${limit_str,,}" =~ ^([0-9]+)(mb|gb|kb|b)$ ]]; then
-        quota=$(parse_bytes "$limit_str")
-        days=30
+        quota=$(parse_human_bytes "$limit_str") || {
+            log_error "Invalid quota format: ${limit_str}"
+            return 1
+        }
     else
         log_error "Invalid limit format. Use e.g. 12h, 24h, 7d, 500mb, 1gb."
         return 1
     fi
+
+    if [ "$quota" -eq 0 ] && [ -z "$expires" ]; then
+        log_error "Failed to calculate guest expiry"
+        return 1
+    fi
     
-    log_info "Creating disposable guest link '${label}'..."
-    secret_add "$label" "" "true"
-    secret_set_limits "$label" "0" "0" "${quota}" "${expires}" "true"
-    run_secret note "$label" "$note"
-    reload_proxy_config
-    log_success "Burner link '${label}' created successfully!"
+    log_info "Creating disposable guest link '${guest_label}'..."
+    secret_add "$guest_label" "" "true" || return 1
+    secret_set_limits "$guest_label" "0" "0" "${quota}" "${expires}" "true" || return 1
+    secret_edit_note "$guest_label" "$note" || return 1
+    reload_proxy_config || return 1
+    log_success "Burner link '${guest_label}' created successfully!"
 }
 
 run_pool() {

--- a/tests/test_guest.sh
+++ b/tests/test_guest.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+# Regression tests for disposable guest access creation.
+set -o pipefail
+
+if [ "${BASH_VERSINFO[0]:-0}" -lt 4 ] || \
+   { [ "${BASH_VERSINFO[0]}" -eq 4 ] && [ "${BASH_VERSINFO[1]:-0}" -lt 2 ]; }; then
+    echo "SKIP: bash 4.2+ required (got ${BASH_VERSION:-unknown})" >&2
+    exit 0
+fi
+
+TEST_TMPDIR=$(mktemp -d)
+INSTALL_DIR="$TEST_TMPDIR/install"
+mkdir -p "$INSTALL_DIR"
+
+MTPROXYMAX_SOURCE_ONLY=true source "$(dirname "$0")/../mtproxymax.sh"
+set +e
+trap 'rm -rf "$TEST_TMPDIR"' EXIT
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+assert_eq() {
+    local name="$1" want="$2" got="$3"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if [ "$got" = "$want" ]; then
+        printf '  PASS  %s\n' "$name"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        printf '  FAIL  %s (got=%q want=%q)\n' "$name" "$got" "$want"
+    fi
+}
+
+assert_status() {
+    assert_eq "$1" "$2" "$3"
+}
+
+# Exercise the production load_secrets function. Its read variables previously
+# clobbered run_guest's local `label` through Bash dynamic scoping.
+cat > "$SECRETS_FILE" <<'SECRETS'
+# existing data
+existing|0123456789abcdef0123456789abcdef|0|true|0|0|0|0||
+SECRETS
+
+load_settings() { :; }
+check_root() { :; }
+log_info() { :; }
+log_success() { :; }
+log_error() { :; }
+
+CAPTURED_LABEL=""
+CAPTURED_QUOTA=""
+CAPTURED_EXPIRY=""
+CAPTURED_NOTE=""
+RELOADS=0
+
+secret_add() {
+    CAPTURED_LABEL="$1"
+    return 0
+}
+
+secret_set_limits() {
+    CAPTURED_LABEL="$1"
+    CAPTURED_QUOTA="$4"
+    CAPTURED_EXPIRY="$5"
+    return 0
+}
+
+secret_edit_note() {
+    CAPTURED_LABEL="$1"
+    CAPTURED_NOTE="$2"
+    return 0
+}
+
+reload_proxy_config() {
+    RELOADS=$((RELOADS + 1))
+    return 0
+}
+
+echo "Guest access tests"
+
+run_guest trial24 24h
+status=$?
+assert_status "24h guest creation succeeds" 0 "$status"
+assert_eq "label survives load_secrets" "trial24" "$CAPTURED_LABEL"
+assert_eq "24h guest has no quota" "0" "$CAPTURED_QUOTA"
+[[ "$CAPTURED_EXPIRY" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]]
+assert_status "24h guest gets RFC 3339 expiry" 0 "$?"
+assert_eq "24h guest note is recorded" "🔥 Burner link (24h)" "$CAPTURED_NOTE"
+assert_eq "configuration reloads once" "1" "$RELOADS"
+
+CAPTURED_QUOTA=""
+CAPTURED_EXPIRY=""
+CAPTURED_NOTE=""
+RELOADS=0
+
+run_guest trial1g 1gb
+status=$?
+assert_status "quota guest creation succeeds" 0 "$status"
+assert_eq "quota label survives load_secrets" "trial1g" "$CAPTURED_LABEL"
+assert_eq "1gb is converted to bytes" "1073741824" "$CAPTURED_QUOTA"
+assert_eq "quota-only guest has no expiry" "" "$CAPTURED_EXPIRY"
+assert_eq "quota guest note is recorded" "🔥 Burner link (1gb)" "$CAPTURED_NOTE"
+assert_eq "quota configuration reloads once" "1" "$RELOADS"
+
+run_guest trial invalid
+assert_status "invalid guest limit is rejected" 1 "$?"
+
+printf '\n%d tests, %d failures\n' "$TESTS_RUN" "$TESTS_FAILED"
+[ "$TESTS_FAILED" -eq 0 ]


### PR DESCRIPTION
## Summary

  - Preserve the guest label across `load_secrets`.
  - Replace the missing `parse_bytes` call with `parse_human_bytes`.
  - Replace stale `run_secret note` calls with `secret_edit_note`.
  - Propagate failures from secret creation, limit assignment, note updates, and config reload.
  - Add regression tests for time-based and quota-based guest access.

  ## Problem

  `mtproxymax guest trial24 24h` received the label correctly, but `load_secrets` reused the dynamically scoped Bash variable named `label` and cleared its
  value.

  The command therefore continued as:

  ```text
  Creating disposable guest link ''...
  Label is required
  ```

  Quota-based guests also called the nonexistent `parse_bytes` function, while note assignment called the nonexistent `run_secret` function.

  ## Result

  The following commands now work:

  ```bash
  mtproxymax guest trial24 24h
  mtproxymax guest trial7d 7d
  mtproxymax guest trial500 500mb
  mtproxymax guest trial1g 1gb
  ```
  ## Tests

  - `bash -n mtproxymax.sh`
  - `bash tests/test_guest.sh` — 13 passed
  - `bash tests/test_secret_command_status.sh` — 7 passed
  - `bash tests/test_replication.sh` — 112 passed
  - `git diff --check`

