### PR TITLE
fix(traffic): synchronize resets with telegram daemon

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ Fine-grained limits enforced at the engine level:
 
 > **Tip:** Each Telegram app opens **~3 TCP connections** (one per DC). So for device limiting, multiply by 3: `conns 15` ≈ max 5 devices. Setting below 5 will likely break even a single device. IP limits are less reliable because mobile users roam between cell towers (briefly showing 2 IPs for 1 device), and multiple devices behind the same WiFi share 1 IP. Use `ips` as a secondary anti-sharing measure.
 >
-> **Traffic and quotas are lifetime (cumulative)**, not monthly. They don't auto-reset. Use `mtproxymax secret reset-traffic <label>` to manually reset counters, or rotate the secret.
+> **Traffic and quotas are cumulative by default.** Use `mtproxymax secret quota-reset <label> <day>` for a recurring monthly quota period, or `mtproxymax secret reset-traffic <label>` to start a new period manually. `mtproxymax traffic` shows usage since each counter's most recent reset; its server-wide `Total` is independent from per-user resets.
 
 ```bash
 mtproxymax secret setlimits alice 100 5 10G 2026-12-31
@@ -769,6 +769,9 @@ Automatic scheduled operations — no cron setup required (runs from the Telegra
 mtproxymax secret quota-reset alice 1          # Reset on the 1st
 mtproxymax secret quota-reset bob 15           # Reset on the 15th
 mtproxymax secret quota-reset alice off        # Disable
+
+# Reset the independent server-wide total (does not change user quotas)
+mtproxymax traffic reset-global
 
 # Global auto-rotate — rotates secrets older than N days
 mtproxymax auto-rotate 90                      # Rotate every 90 days

--- a/mtproxymax.sh
+++ b/mtproxymax.sh
@@ -2540,14 +2540,33 @@ secret_reset_traffic() {
     local _ut="${STATS_DIR}/user_traffic"
     local _snap="${STATS_DIR}/user_traffic_snapshot"
     local _qa="${STATS_DIR}/.quota_alerts_sent"
+    local _pending="${STATS_DIR}/.traffic_reset_pending"
     mkdir -p "${STATS_DIR}" 2>/dev/null
+
+    # A reset needs a live baseline. Without it the engine's lifetime
+    # Prometheus counters would appear as newly consumed traffic immediately.
+    local _reset_metrics
+    if ! _reset_metrics=$(_fetch_metrics 2>/dev/null) || [ -z "$_reset_metrics" ]; then
+        log_error "Cannot reset traffic: live metrics are unavailable."
+        return 1
+    fi
+
+    # A running Telegram daemon keeps its own counters in memory. Serialize the
+    # disk update with save_traffic() and leave it a reset command to consume
+    # before its next write, otherwise it would restore the pre-reset values.
+    exec 9>"${STATS_DIR}/.traffic.lock"
+    flock -w 5 9 2>/dev/null || {
+        log_error "Could not acquire traffic lock. Telegram daemon may be busy."
+        exec 9>&-
+        return 1
+    }
 
     if [ "$label" = "all" ]; then
         : > "$_ut" 2>/dev/null || true
         : > "$_qa" 2>/dev/null || true
         # Update snapshot with current live Prometheus values so delta becomes 0 right now
-        local _m
-        if _m=$(_fetch_metrics 2>/dev/null) && [ -n "$_m" ]; then
+        local _m="$_reset_metrics"
+        if [ -n "$_m" ]; then
             echo "$_m" | awk '
                 function get_user(s,   p,q) {
                     p = index(s, "user=\"")
@@ -2567,6 +2586,8 @@ secret_reset_traffic() {
         else
             : > "$_snap" 2>/dev/null || true
         fi
+        printf 'users-all\n' >> "$_pending"
+        chmod 600 "$_ut" "$_qa" "$_snap" "$_pending" 2>/dev/null || true
         log_success "Traffic counters reset for all users"
     else
         # Verify label exists
@@ -2574,7 +2595,11 @@ secret_reset_traffic() {
         for i in "${!SECRETS_LABELS[@]}"; do
             [ "${SECRETS_LABELS[$i]}" = "$label" ] && { found=true; break; }
         done
-        [ "$found" = "false" ] && { log_error "Secret '${label}' not found"; return 1; }
+        if [ "$found" = "false" ]; then
+            log_error "Secret '${label}' not found"
+            exec 9>&-
+            return 1
+        fi
 
         # Clear saved user_traffic and quota alerts
         for f in "$_ut" "$_qa"; do
@@ -2583,7 +2608,8 @@ secret_reset_traffic() {
 
         # Update user_traffic_snapshot to exact current live Prometheus values so delta becomes 0 right now
         local live_in=0 live_out=0
-        read -r live_in live_out _ <<< "$(get_user_stats "$label" 2>/dev/null)"
+        live_in=$(echo "$_reset_metrics" | awk -v u="$label" '$0 ~ "^telemt_user_octets_from_client\\{.*user=\"" u "\"" {s+=$NF} END {printf "%.0f",s}')
+        live_out=$(echo "$_reset_metrics" | awk -v u="$label" '$0 ~ "^telemt_user_octets_to_client\\{.*user=\"" u "\"" {s+=$NF} END {printf "%.0f",s}')
         [[ "${live_in:-0}" =~ ^[0-9]+$ ]] || live_in=0
         [[ "${live_out:-0}" =~ ^[0-9]+$ ]] || live_out=0
         if [ -f "$_snap" ]; then
@@ -2591,8 +2617,12 @@ secret_reset_traffic() {
             mv "${_snap}.tmp" "$_snap" 2>/dev/null || true
         fi
         echo "${label}|${live_in}|${live_out}" >> "$_snap"
+        printf 'user|%s|%s|%s\n' "$label" "$live_in" "$live_out" >> "$_pending"
+        chmod 600 "$_ut" "$_qa" "$_snap" "$_pending" 2>/dev/null || true
         log_success "Traffic counters reset for '${label}'"
     fi
+
+    exec 9>&-
 
     if [ "${no_reload:-}" != "no_reload" ]; then
         load_settings 2>/dev/null || true
@@ -6355,20 +6385,32 @@ run_traffic_reset_global() {
     
     log_info "Fetching current live metrics baseline..."
     local _metrics
-    _metrics=$(curl -s --max-time 2 "http://127.0.0.1:${PROXY_METRICS_PORT:-9090}/metrics" 2>/dev/null) || true
-    local cur_in=0 cur_out=0
-    if [ -n "$_metrics" ]; then
-        cur_in=$(echo "$_metrics"|awk '/^telemt_user_octets_from_client\{/{s+=$NF}END{printf "%.0f",s}')
-        cur_out=$(echo "$_metrics"|awk '/^telemt_user_octets_to_client\{/{s+=$NF}END{printf "%.0f",s}')
-        cur_in=${cur_in:-0}; cur_out=${cur_out:-0}
+    if ! _metrics=$(curl -fsS --max-time 2 "http://127.0.0.1:${PROXY_METRICS_PORT:-9090}/metrics" 2>/dev/null); then
+        log_error "Cannot reset traffic: live metrics are unavailable."
+        return 1
     fi
+    local cur_in=0 cur_out=0
+    cur_in=$(echo "$_metrics"|awk '/^telemt_user_octets_from_client\{/{s+=$NF}END{printf "%.0f",s}')
+    cur_out=$(echo "$_metrics"|awk '/^telemt_user_octets_to_client\{/{s+=$NF}END{printf "%.0f",s}')
+    cur_in=${cur_in:-0}; cur_out=${cur_out:-0}
     
     log_info "Resetting cumulative counters..."
     exec 9>"${_stats_dir}/.traffic.lock"
     flock -w 5 9 2>/dev/null || { log_error "Could not acquire traffic lock. Daemon may be busy."; exec 9>&-; return 1; }
     
-    echo "0|0" > "${_stats_dir}/cumulative_traffic"
-    echo "${cur_in}|${cur_out}" > "${_stats_dir}/global_traffic_snapshot"
+    local _tmp
+    _tmp=$(_mktemp "$_stats_dir") || { exec 9>&-; return 1; }
+    echo "0|0" > "$_tmp"
+    chmod 600 "$_tmp"
+    mv "$_tmp" "${_stats_dir}/cumulative_traffic"
+
+    _tmp=$(_mktemp "$_stats_dir") || { exec 9>&-; return 1; }
+    echo "${cur_in}|${cur_out}" > "$_tmp"
+    chmod 600 "$_tmp"
+    mv "$_tmp" "${_stats_dir}/global_traffic_snapshot"
+
+    printf 'global|%s|%s\n' "$cur_in" "$cur_out" >> "${_stats_dir}/.traffic_reset_pending"
+    chmod 600 "${_stats_dir}/.traffic_reset_pending" 2>/dev/null || true
     
     exec 9>&-
     
@@ -10938,6 +10980,50 @@ _cum_in=0
 _cum_out=0
 declare -A _prev_user_in _prev_user_out _cum_user_in _cum_user_out
 
+apply_pending_traffic_resets() {
+    local _pending="${INSTALL_DIR}/relay_stats/.traffic_reset_pending"
+    [ -s "$_pending" ] || return 0
+
+    local _kind _label _in _out
+    while IFS='|' read -r _kind _label _in _out; do
+        case "$_kind" in
+            global)
+                [[ "${_label:-}" =~ ^[0-9]+$ ]] || _label=0
+                [[ "${_in:-}" =~ ^[0-9]+$ ]] || _in=0
+                _cum_in=0
+                _cum_out=0
+                _prev_total_in="$_label"
+                _prev_total_out="$_in"
+                ;;
+            user)
+                [[ "$_label" =~ ^[a-zA-Z0-9_-]+$ ]] || continue
+                [[ "${_in:-}" =~ ^[0-9]+$ ]] || _in=0
+                [[ "${_out:-}" =~ ^[0-9]+$ ]] || _out=0
+                _cum_user_in["$_label"]=0
+                _cum_user_out["$_label"]=0
+                _prev_user_in["$_label"]="$_in"
+                _prev_user_out["$_label"]="$_out"
+                ;;
+            users-all)
+                _cum_user_in=()
+                _cum_user_out=()
+                _prev_user_in=()
+                _prev_user_out=()
+                if [ -f "${INSTALL_DIR}/relay_stats/user_traffic_snapshot" ]; then
+                    while IFS='|' read -r _label _in _out; do
+                        [[ "$_label" =~ ^[a-zA-Z0-9_-]+$ ]] || continue
+                        [[ "${_in:-}" =~ ^[0-9]+$ ]] || _in=0
+                        [[ "${_out:-}" =~ ^[0-9]+$ ]] || _out=0
+                        _prev_user_in["$_label"]="$_in"
+                        _prev_user_out["$_label"]="$_out"
+                    done < "${INSTALL_DIR}/relay_stats/user_traffic_snapshot"
+                fi
+                ;;
+        esac
+    done < "$_pending"
+    rm -f "$_pending"
+}
+
 load_traffic() {
     if [ -f "$TRAFFIC_FILE" ]; then
         IFS='|' read -r _cum_in _cum_out < "$TRAFFIC_FILE"
@@ -10985,6 +11071,7 @@ save_traffic() {
     # Acquire lock to prevent race with flush_traffic_to_disk
     exec 9>"${_tdir}/.traffic.lock"
     flock -w 5 9 2>/dev/null || { exec 9>&- 2>/dev/null; return 0; }
+    apply_pending_traffic_resets
     local _tmp=$(mktemp "${_tdir}/.traffic.XXXXXX" 2>/dev/null) || { exec 9>&-; return; }
     chmod 600 "$_tmp"
     echo "${_cum_in}|${_cum_out}" > "$_tmp"

--- a/tests/test_traffic_reset.sh
+++ b/tests/test_traffic_reset.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+# Regression tests for traffic resets while the Telegram daemon is running.
+set -o pipefail
+
+if [ "${BASH_VERSINFO[0]:-0}" -lt 4 ]; then
+    echo "SKIP: bash 4+ required (got ${BASH_VERSION:-unknown})" >&2
+    exit 0
+fi
+
+TEST_TMPDIR=$(mktemp -d)
+INSTALL_DIR="$TEST_TMPDIR/install"
+mkdir -p "$INSTALL_DIR/relay_stats"
+
+MTPROXYMAX_SOURCE_ONLY=true source "$(dirname "$0")/../mtproxymax.sh"
+set +e
+trap 'rm -rf "$TEST_TMPDIR"' EXIT
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+assert_eq() {
+    local name="$1" want="$2" got="$3"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if [ "$got" = "$want" ]; then
+        printf '  PASS  %s\n' "$name"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        printf '  FAIL  %s (got=%q want=%q)\n' "$name" "$got" "$want"
+    fi
+}
+
+check_root() { :; }
+load_settings() { :; }
+reload_proxy_config() { :; }
+log_info() { :; }
+log_success() { :; }
+log_error() { LAST_ERROR="$*"; }
+audit_log() { :; }
+
+SECRETS_LABELS=(alice bob)
+SECRETS_ENABLED=(true true)
+
+METRICS='# HELP test test
+telemt_user_octets_from_client{user="alice"} 120
+telemt_user_octets_to_client{user="alice"} 340
+telemt_user_octets_from_client{user="bob"} 50
+telemt_user_octets_to_client{user="bob"} 70'
+
+_fetch_metrics() {
+    [ "${METRICS_AVAILABLE:-true}" = "true" ] || return 1
+    printf '%s\n' "$METRICS"
+}
+
+curl() {
+    [ "${METRICS_AVAILABLE:-true}" = "true" ] || return 22
+    printf '%s\n' "$METRICS"
+}
+
+echo "Traffic reset tests"
+
+printf 'alice|1000|2000\nbob|3000|4000\n' > "$STATS_DIR/user_traffic"
+printf 'alice|10|20\nbob|30|40\n' > "$STATS_DIR/user_traffic_snapshot"
+
+secret_reset_traffic alice no_reload
+assert_eq "user reset succeeds" 0 "$?"
+assert_eq "user cumulative row is removed" "bob|3000|4000" "$(cat "$STATS_DIR/user_traffic")"
+assert_eq "user live baseline is saved" "alice|120|340" "$(grep '^alice|' "$STATS_DIR/user_traffic_snapshot")"
+assert_eq "daemon reset command is queued" "user|alice|120|340" "$(cat "$STATS_DIR/.traffic_reset_pending")"
+
+# Extract and exercise the exact self-contained daemon helper. Its stale
+# in-memory counters must be replaced before save_traffic writes again.
+telegram_generate_service_script
+awk '/^apply_pending_traffic_resets\(\)/,/^}/' "$INSTALL_DIR/mtproxymax-telegram.sh" > "$TEST_TMPDIR/apply-reset.sh"
+source "$TEST_TMPDIR/apply-reset.sh"
+_cum_user_in[alice]=1000
+_cum_user_out[alice]=2000
+_prev_user_in[alice]=10
+_prev_user_out[alice]=20
+apply_pending_traffic_resets
+assert_eq "daemon cumulative input is cleared" 0 "${_cum_user_in[alice]}"
+assert_eq "daemon cumulative output is cleared" 0 "${_cum_user_out[alice]}"
+assert_eq "daemon input baseline is updated" 120 "${_prev_user_in[alice]}"
+assert_eq "daemon output baseline is updated" 340 "${_prev_user_out[alice]}"
+assert_eq "daemon consumes reset command" "missing" "$([ -e "$STATS_DIR/.traffic_reset_pending" ] && echo present || echo missing)"
+
+printf '999|888\n' > "$STATS_DIR/cumulative_traffic"
+printf '1|2\n' > "$STATS_DIR/global_traffic_snapshot"
+run_traffic_reset_global --force
+assert_eq "global reset succeeds" 0 "$?"
+assert_eq "global cumulative counter is zero" "0|0" "$(cat "$STATS_DIR/cumulative_traffic")"
+assert_eq "global live baseline is saved" "170|410" "$(cat "$STATS_DIR/global_traffic_snapshot")"
+assert_eq "global daemon reset is queued" "global|170|410" "$(cat "$STATS_DIR/.traffic_reset_pending")"
+
+_cum_in=999
+_cum_out=888
+_prev_total_in=1
+_prev_total_out=2
+apply_pending_traffic_resets
+assert_eq "daemon global input is cleared" 0 "$_cum_in"
+assert_eq "daemon global output is cleared" 0 "$_cum_out"
+assert_eq "daemon global input baseline is updated" 170 "$_prev_total_in"
+assert_eq "daemon global output baseline is updated" 410 "$_prev_total_out"
+
+METRICS_AVAILABLE=false
+printf '5|6\n' > "$STATS_DIR/cumulative_traffic"
+run_traffic_reset_global --force >/dev/null
+assert_eq "global reset fails without metrics" 1 "$?"
+assert_eq "failed reset preserves counters" "5|6" "$(cat "$STATS_DIR/cumulative_traffic")"
+
+METRICS_AVAILABLE=true
+printf 'bob|3000|4000\n' > "$STATS_DIR/user_traffic"
+printf 'bob|30|40\n' > "$STATS_DIR/user_traffic_snapshot"
+printf 'bob|1\n' > "$INSTALL_DIR/secrets_quota_reset.conf"
+: > "$STATS_DIR/.quota_reset_log"
+secret_check_quota_resets
+assert_eq "monthly reset records the current period" "bob|$(date +%Y-%m)" "$(cat "$STATS_DIR/.quota_reset_log")"
+assert_eq "monthly reset clears the user's disk counter" "" "$(cat "$STATS_DIR/user_traffic")"
+assert_eq "monthly reset queues daemon synchronization" "user|bob|50|70" "$(cat "$STATS_DIR/.traffic_reset_pending")"
+_cum_user_in[bob]=3000
+_cum_user_out[bob]=4000
+apply_pending_traffic_resets
+assert_eq "monthly reset clears stale daemon input" 0 "${_cum_user_in[bob]}"
+assert_eq "monthly reset clears stale daemon output" 0 "${_cum_user_out[bob]}"
+
+printf '\n%d tests, %d failures\n' "$TESTS_RUN" "$TESTS_FAILED"
+[ "$TESTS_FAILED" -eq 0 ]


### PR DESCRIPTION
## Summary

  Fix traffic counters being restored by the running Telegram daemon after manual or scheduled resets.

  ## Problem

  Traffic reset commands updated the files on disk, while the Telegram daemon retained the old cumulative values in memory. On its next 60-second update, it
  wrote those stale values back.

  This affected:

  - `mtproxymax secret reset-traffic <label|all>`
  - monthly resets configured with `secret quota-reset`
  - `mtproxymax traffic reset-global`

  The monthly reset could be recorded as completed in `.quota_reset_log`, even though the old traffic values subsequently returned.

## Changes

  - Serialize user resets with the daemon traffic lock.
  - Queue reset notifications for the running Telegram daemon.
  - Apply queued resets to its in-memory cumulative counters and Prometheus baselines before saving.
  - Synchronize individual, all-user and global resets.
  - Refuse resets when live metrics are unavailable, preventing traffic from immediately reappearing.
  - Use atomic, permission-protected files for global counters.
  - Clarify the difference between per-user usage periods and the independent server-wide total.
  - Add regression coverage for manual, global and scheduled monthly resets.

  ## Tests

  - 24 new traffic-reset regression tests.
  - All existing tests pass.
  - Bash syntax and `git diff --check` pass.

